### PR TITLE
Fix "EventEmitter memory leak detected" warnings

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,8 +13,8 @@ module.exports = (port, opts) => {
 		};
 
 		socket.setTimeout(opts.timeout);
-		socket.on('error', onError);
-		socket.on('timeout', onError);
+		socket.once('error', onError);
+		socket.once('timeout', onError);
 
 		socket.connect(port, opts.host, () => {
 			socket.end();


### PR DESCRIPTION
Once the event is emitted it isn't removed.
This creates a warning:
`possible EventEmitter memory leak detected. 11 listeners added. Use emitter.setMaxListeners() to increase limit.`

It happened to me upon massive usage.

I used this to fix it and it helped for sure:
https://stackoverflow.com/questions/9768444/possible-eventemitter-memory-leak-detected